### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     methods,
     tibble (>= 3.1.0),
     ggplot2 (>= 3.3.0),
-    rstan (>= 2.21.0),
+    rstan (>= 2.26.0),
     assertthat,
     stringr,
     shiny,
@@ -36,8 +36,8 @@ Suggests:
     parallelly,
     rstantools
 LinkingTo:
-    StanHeaders (>= 2.21.0),
-    rstan (>= 2.21.0),
+    StanHeaders (>= 2.26.0),
+    rstan (>= 2.26.0),
     BH (>= 1.72.0-1),
     Rcpp (>= 1.0.3),
     RcppEigen (>= 0.3.3.7.0),

--- a/inst/stan/linexp_gastro_1b.stan
+++ b/inst/stan/linexp_gastro_1b.stan
@@ -7,7 +7,7 @@ data{
   real prior_v0;
   int<lower=0> n; // Number of data
   int<lower=0> n_record; // Number of records
-  int record[n];
+  array[n] int record;
   vector[n] minute;
   vector[n] volume;
 }
@@ -27,7 +27,7 @@ model{
   real v0r;
   real kappar;
   real temptr;
-  real vol[n];
+  array[n] real vol;
   mu_kappa ~ normal(1.5,0.5);
   sigma_kappa ~ normal(1,0.5);
 

--- a/inst/stan/linexp_gastro_2b.stan
+++ b/inst/stan/linexp_gastro_2b.stan
@@ -13,7 +13,7 @@ data{
   int student_df; // 3 to 9
   int<lower=0> n; // Number of data
   int<lower=0> n_record; // Number of records, used for v0
-  int record[n];
+  array[n] int record;
   vector[n] minute;
   vector[n] volume;
 }
@@ -46,7 +46,7 @@ parameters{
   real <lower=0> mu_tempt;
   corr_matrix[2] rho;
   real<lower=0> sigma;
-  vector[2] cf[n_record];
+  array[n_record] vector[2] cf;
 }
 
 transformed parameters{

--- a/inst/stan/powexp_gastro_1b.stan
+++ b/inst/stan/powexp_gastro_1b.stan
@@ -7,7 +7,7 @@ data{
   real prior_v0;
   int<lower=0> n; // Number of data
   int<lower=0> n_record; // Number of records
-  int record[n];
+  array[n] int record;
   vector[n] minute;
   vector[n] volume;
 }
@@ -27,7 +27,7 @@ model{
   real v0r;
   real betar;
   real temptr;
-  real vol[n];
+  array[n] real vol;
   mu_beta ~ normal(1.5,0.5);
   sigma_beta ~ normal(1,0.5);
 

--- a/inst/stan/powexp_gastro_2c.stan
+++ b/inst/stan/powexp_gastro_2c.stan
@@ -14,7 +14,7 @@ data{
   int student_df; // 3 to 9
   int<lower=0> n; // Number of data
   int<lower=0> n_record; // Number of records, used for v0
-  int record[n];
+  array[n] int record;
   vector[n] minute;
   vector[n] volume;
 }


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
